### PR TITLE
[Taus] Include taus

### DIFF
--- a/objectPerformance/cfg_caching/V22.yaml
+++ b/objectPerformance/cfg_caching/V22.yaml
@@ -37,4 +37,9 @@ V22:
     trees_branches: {}
   GluGluToHHTo2B2Tau:
     ntuple_path: /eos/cms/store/cmst3/group/l1tr/phase2Menu/EmuDev/GluGluToHHTo2B2Tau_node_SM_TuneCP5_14TeV-madgraph-pythia8/GGToHHTo2B2Tau_PU200_v22/220408_073133/0000//L1NtuplePhaseII_Step1_*.root
-    trees_branches: {}
+    trees_branches:
+      genTree/L1GenTree:
+        part_tau: [Id, Stat, Pt, Eta, Phi, Parent, E]
+      l1PhaseIITree/L1PhaseIITree:
+        nnTau: [Et, Eta, Pt, Phi, FullIso, Z0, PassTightNN, Chg, DXY, PassLooseNN]
+        caloTau: [Et, Eta, Pt, Phi, Iso, HwQual, Bx]

--- a/objectPerformance/cfg_plots/electron_matching_eta.yaml
+++ b/objectPerformance/cfg_plots/electron_matching_eta.yaml
@@ -11,14 +11,15 @@ ElectronsMatching_Eta_Pt10to25:
         - "{pt} < 25"
         - "{pt} > 10"
       object:
-        - "abs({eta}) < 2.4"
+        - "abs({eta}) < 2.8"
   test_objects:
     tkElectron:
       suffix: "Eta"
       label: "TkElectron"
       quality_id: "QUAL_BarrelNoneEndcap3"
       cuts:
-        - "abs({eta}) < 2.4"
+        - "abs({eta}) < 2.8"
+        - "{passesloosetrackid} == 1"
   xlabel: "Gen. $\\eta$"
   ylabel: "Matching Efficiency ($10 < p_T < 25$ GeV)"
   match_dR: 0.15
@@ -35,17 +36,18 @@ ElectronsMatching_Eta_Pt25toInf:
     suffix: "Eta"
     label: "Gen Electrons"
     cuts:
-      object:
-        - "abs({eta}) < 2.4"
       event:
         - "{dr_0.3} < 0.15"
         - "{pt} > 25"
+      object:
+        - "abs({eta}) < 2.8"
   test_objects:
     tkElectron:
       suffix: "Eta"
       label: "TkElectron"
       cuts:
-        - "abs({eta}) < 2.4"
+        - "abs({eta}) < 2.8"
+        - "{passesloosetrackid} == 1"
   xlabel: "Gen. $\\eta$"
   ylabel: "Matching Efficiency ($p_T > 25$ GeV)"
   match_dR: 0.15

--- a/objectPerformance/cfg_plots/electron_trigger.yaml
+++ b/objectPerformance/cfg_plots/electron_trigger.yaml
@@ -1,4 +1,4 @@
-ElectronsMatchingBarrel:
+ElectronsTriggerBarrel:
   sample: DY
   default_version: V22
   reference_object:
@@ -10,24 +10,27 @@ ElectronsMatchingBarrel:
         - "{dr_0.3} < 0.15"
         - "abs({eta}) < 1.5"
       object:
-        - "abs({eta}) < 2.4"
+        - "abs({eta}) < 2.8"
   test_objects:
     tkElectron:
       suffix: "Pt"
-      label: "TkElectron"
-      quality_id: "QUAL_BarrelNoneEndcap3"
+      label: "tkElectron"
+      match_dR: 0.15
       cuts:
-        - "abs({eta}) < 2.4"
         - "{passesloosetrackid} == 1"
-  xlabel: "Gen. $p_T$ (GeV)"
-  ylabel: "Matching Efficiency (Barrel)"
-  match_dR: 0.15
+        - "abs({eta}) < 2.8"
+  thresholds: [10, 20, 30, 40]
+  scalings:
+    method: "naive"
+    threshold: 0.95
+  xlabel: "Gen. pT (GeV)"
+  ylabel: "Trigger Efficiency (barrel, L1 $p_T > <threshold>$ GeV)"
   binning:
     min: 0
     max: 150
-    step: 3
+    step: 1.5
 
-ElectronsMatchingEndcap:
+ElectronsTriggerEndcap:
   sample: DY
   default_version: V22
   reference_object:
@@ -36,22 +39,25 @@ ElectronsMatchingEndcap:
     label: "Gen Electrons"
     cuts:
       event:
-        - "{dr_0.3} < 0.15" 
+        - "{dr_0.3} < 0.15"
         - "abs({eta}) > 1.5"
       object:
-        - "abs({eta}) < 2.4"
+        - "abs({eta}) < 2.8"
   test_objects:
     tkElectron:
       suffix: "Pt"
-      label: "TkElectron"
+      label: "tkElectron"
+      match_dR: 0.15
       cuts:
-        - "abs({eta}) < 2.4"
         - "{passesloosetrackid} == 1"
-  xlabel: "Gen. $p_T$ (GeV)"
-  ylabel: "Matching Efficiency (Endcap)"
-  match_dR: 0.15
+        - "abs({eta}) < 2.8"
+  thresholds: [10, 20, 30, 40]
+  scalings:
+    method: "naive"
+    threshold: 0.95
+  xlabel: "Gen. pT (GeV)"
+  ylabel: "Trigger Efficiency (endcap, L1 $p_T > <threshold>$ GeV)"
   binning:
     min: 0
     max: 150
-    step: 3
-
+    step: 1.5

--- a/objectPerformance/cfg_plots/muon_matching.yaml
+++ b/objectPerformance/cfg_plots/muon_matching.yaml
@@ -1,7 +1,7 @@
 MuonsMatchingBarrel:
   sample: DY
   default_version: V22
-  reference_object: 
+  reference_object:
     object: "part_mu"
     suffix: "Pt"
     label: "Gen Muons"
@@ -25,17 +25,15 @@ MuonsMatchingBarrel:
         - "abs({eta}) < 0.83"
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Matching Efficiency (barrel)"
-  thresholds: [0]
-  scaling_pct: 0.95
   binning:
     min: 0
-    max: 150 
+    max: 150
     step: 3
 
 MuonsMatchingOverlap:
   sample: DY
   default_version: V22
-  reference_object: 
+  reference_object:
     object: "part_mu"
     suffix: "Pt"
     label: "Gen Muons"
@@ -62,16 +60,15 @@ MuonsMatchingOverlap:
         - "abs({eta}) < 1.24"
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Matching Efficiency (overlap)"
-  thresholds: [0]
   binning:
     min: 0
-    max: 150 
+    max: 150
     step: 3
 
 MuonsMatchingEndcap:
   sample: DY
   default_version: V22
-  reference_object: 
+  reference_object:
     object: "part_mu"
     suffix: "Pt"
     label: "Gen Muons"
@@ -79,7 +76,7 @@ MuonsMatchingEndcap:
       event:
         - "{dr_0.3} < 0.15"
       object:
-        - "abs({eta}) > 0.83"
+        - "abs({eta}) > 1.24"
         - "abs({eta}) < 2.4"
   test_objects:
     gmtMuon:
@@ -87,20 +84,18 @@ MuonsMatchingEndcap:
       label: "GMT Muon"
       match_dR: 0.3
       cuts:
-        - "abs({eta}) > 0.83"
+        - "abs({eta}) > 1.24"
         - "abs({eta}) < 2.4"
     gmtTkMuon:
       suffix: "Pt"
       label: "GMT TkMuon"
       match_dR: 0.1
       cuts:
-        - "abs({eta}) > 0.83"
+        - "abs({eta}) > 1.24"
         - "abs({eta}) < 2.4"
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Matching Efficiency (endcap)"
-  thresholds: [0]
   binning:
     min: 0
-    max: 150 
+    max: 150
     step: 3
-

--- a/objectPerformance/cfg_plots/muon_matching_eta.yaml
+++ b/objectPerformance/cfg_plots/muon_matching_eta.yaml
@@ -1,7 +1,7 @@
 MuonsMatching_Eta_Pt2to5:
   sample: DY
   default_version: V22
-  reference_object: 
+  reference_object:
     object: "part_mu"
     suffix: "Eta"
     label: "Gen Muons"
@@ -27,7 +27,7 @@ MuonsMatching_Eta_Pt2to5:
 MuonsMatching_Eta_Pt15toInf:
   sample: DY
   default_version: V22
-  reference_object: 
+  reference_object:
     object: "part_mu"
     suffix: "Eta"
     label: "Gen Muons"
@@ -38,10 +38,6 @@ MuonsMatching_Eta_Pt15toInf:
       object:
         - "abs({eta}) < 2.4"
   test_objects:
-    gmtMuon:
-      suffix: "Eta"
-      label: "GMT Muon"
-      match_dR: 0.3
     gmtTkMuon:
       suffix: "Eta"
       label: "GMT TkMuon"
@@ -52,4 +48,3 @@ MuonsMatching_Eta_Pt15toInf:
     min: -3
     max: 3
     step: 0.2
-

--- a/objectPerformance/cfg_plots/tau_matching.yaml
+++ b/objectPerformance/cfg_plots/tau_matching.yaml
@@ -1,10 +1,10 @@
-ElectronsMatchingBarrel:
-  sample: DY
+TausMatchingBarrel:
+  sample: GluGluToGG
   default_version: V22
   reference_object:
-    object: "part_e"
+    object: "part_tau"
     suffix: "Pt"
-    label: "Gen Electrons"
+    label: "Gen Taus"
     cuts:
       event:
         - "{dr_0.3} < 0.15"
@@ -12,46 +12,56 @@ ElectronsMatchingBarrel:
       object:
         - "abs({eta}) < 2.4"
   test_objects:
-    tkElectron:
+    nnTau:
       suffix: "Pt"
-      label: "TkElectron"
-      quality_id: "QUAL_BarrelNoneEndcap3"
+      label: "NN Tau"
       cuts:
         - "abs({eta}) < 2.4"
-        - "{passesloosetrackid} == 1"
+        - "{passloosenn}==1"
+      match_dR: 0.1
+    caloTau:
+      suffix: "Pt"
+      label: "Calo Tau"
+      cuts:
+        - "abs({eta}) < 2.4"
+      match_dR: 0.3
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Matching Efficiency (Barrel)"
-  match_dR: 0.15
   binning:
     min: 0
     max: 150
-    step: 3
+    step: 6
 
-ElectronsMatchingEndcap:
-  sample: DY
+TausMatchingEndcap:
+  sample: GluGluToGG
   default_version: V22
   reference_object:
-    object: "part_e"
+    object: "part_tau"
     suffix: "Pt"
-    label: "Gen Electrons"
+    label: "Gen Taus"
     cuts:
       event:
-        - "{dr_0.3} < 0.15" 
+        - "{dr_0.3} < 0.15"
         - "abs({eta}) > 1.5"
       object:
         - "abs({eta}) < 2.4"
   test_objects:
-    tkElectron:
+    nnTau:
       suffix: "Pt"
-      label: "TkElectron"
+      label: "NN Tau"
       cuts:
         - "abs({eta}) < 2.4"
-        - "{passesloosetrackid} == 1"
+        - "{passloosenn}==1"
+      match_dR: 0.1
+    caloTau:
+      suffix: "Pt"
+      label: "Calo Tau"
+      cuts:
+        - "abs({eta}) < 2.4"
+      match_dR: 0.3
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Matching Efficiency (Endcap)"
-  match_dR: 0.15
   binning:
     min: 0
     max: 150
-    step: 3
-
+    step: 6

--- a/objectPerformance/src/turnon_collection.py
+++ b/objectPerformance/src/turnon_collection.py
@@ -298,7 +298,7 @@ class TurnOnCollection():
         )
 
         for test_obj, cfg in self.cfg_plot.test_objects.items():
-            sel_threshold = self.numerators["test"][test_obj] > self.threshold
+            sel_threshold = self.numerators["test"][test_obj] >= self.threshold
             numerator = self.numerators["ref"][test_obj][sel_threshold]
             numerator = self._remove_inner_nones_zeros(numerator)
             numerator = self._flatten_array(numerator, ak_to_np=True)


### PR DESCRIPTION
Inclusion of taus in the framework:
* Gen-level taus are included to be equivalent to [`VisTaus` in the C++ framework](https://github.com/FHead/Phase2-L1MenuTools/blob/main/ObjectPerformances/V22Processing/source/HelperFunctions.cpp#L323), i.e. visible component of hadronically-decaying taus.
* Definition of config files (caching and plotting steps) for taus matching efficiency plots
* Few modifications in electron and muon config files to match C++ framework (leading to the results shown in [these slides](https://indico.cern.ch/event/1211533/contributions/5096281/attachments/2528354/4349558/L1Phase2_Validation.pdf))

Comparison C++/python with the code implemented:

![image](https://user-images.githubusercontent.com/19261234/201147295-dc685094-cf52-475f-a753-a0cbc39c569f.png)
